### PR TITLE
Remove `wp_enqueue_scripts` action. Let `hogan-core` handle it

### DIFF
--- a/class-expandable-list.php
+++ b/class-expandable-list.php
@@ -43,10 +43,6 @@ if ( ! class_exists( '\\Dekode\\Hogan\\Expandable_List' ) && class_exists( '\\De
 			$this->label    = __( 'Expandable List', 'hogan-expandable-list' );
 			$this->template = __DIR__ . '/assets/template.php';
 
-			if ( true === apply_filters( 'hogan/module/expandable_list/load_assets', true ) ) {
-				add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
-			}
-
 			parent::__construct();
 		}
 


### PR DESCRIPTION
After https://github.com/DekodeInteraktiv/hogan-core/pull/32 was merged we don't need to add the `wp_enqueue_scripts` action. Hogan core will automagic use `enqueue_assets` when module is in use.