### PR TITLE
Seperate anchor as element that can be offset

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -8,7 +8,7 @@
 	padding-right: 30px;
 }
 
-.hogan-module-expandable_list .hogan-expandable-list-item > a.anchor {
+.hogan-module-expandable_list .hogan-expandable-list-item > .anchor {
 	position: absolute;
 	width: 0;
 	padding: 0;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,7 +1,17 @@
+.hogan-module-expandable_list .hogan-expandable-list-item {
+	position: relative;
+}
+
 .hogan-module-expandable_list .hogan-expandable-list-item > a {
 	display: block;
 	position: relative;
 	padding-right: 30px;
+}
+
+.hogan-module-expandable_list .hogan-expandable-list-item > a.anchor {
+	position: absolute;
+	width: 0;
+	padding: 0;
 }
 
 .hogan-module-expandable_list .hogan-expandable-list-item > a span {

--- a/assets/template.php
+++ b/assets/template.php
@@ -28,8 +28,9 @@ foreach ( $this->list_items as $key => $item ) :
 	$list_item_id      = ! empty( $item['item_id'] ) ? $item['item_id'] : 'panel-' . $this->counter . '-' . $key;
 	?>
 	<div class="<?php echo esc_attr( $list_item_classes ); ?>">
+		<a class="anchor" name="<?php echo esc_attr( $list_item_id ); ?>">&nbsp;</a>
 		<a href="#<?php echo esc_attr( $list_item_id ); ?>"><?php echo esc_html( $item['item_title'] ); ?><span></span></a>
-		<div id="<?php echo esc_attr( $list_item_id ); ?>" aria-expanded="false">
+		<div aria-expanded="false">
 			<?php echo $item['item_content']; // WPCS: XSS OK. ?>
 		</div>
 	</div>

--- a/assets/template.php
+++ b/assets/template.php
@@ -28,7 +28,7 @@ foreach ( $this->list_items as $key => $item ) :
 	$list_item_id      = ! empty( $item['item_id'] ) ? $item['item_id'] : 'panel-' . $this->counter . '-' . $key;
 	?>
 	<div class="<?php echo esc_attr( $list_item_classes ); ?>">
-		<a class="anchor" name="<?php echo esc_attr( $list_item_id ); ?>">&nbsp;</a>
+		<div class="anchor" id="<?php echo esc_attr( $list_item_id ); ?>">&nbsp;</div>
 		<a href="#<?php echo esc_attr( $list_item_id ); ?>"><?php echo esc_html( $item['item_title'] ); ?><span></span></a>
 		<div aria-expanded="false">
 			<?php echo $item['item_content']; // WPCS: XSS OK. ?>

--- a/hogan-expandable-list.php
+++ b/hogan-expandable-list.php
@@ -49,9 +49,9 @@ function register_module( \Dekode\Hogan\Core $core ) {
 /**
  * Sanitize item id name to URL friendly string.
  *
- * @param string $value Item name.
+ * @param string  $value Item name.
  * @param integer $id Item id.
- * @param array $field
+ * @param array   $field Sanitized item name.
  * @return string
  */
 function sanitize_item_id_on_save( string $value, int $id, array $field ) : string {

--- a/hogan-expandable-list.php
+++ b/hogan-expandable-list.php
@@ -46,6 +46,14 @@ function register_module( \Dekode\Hogan\Core $core ) {
 	$core->register_module( new \Dekode\Hogan\Expandable_List() );
 }
 
+/**
+ * Sanitize item id name to URL friendly string.
+ *
+ * @param string $value Item name.
+ * @param integer $id Item id.
+ * @param array $field
+ * @return string
+ */
 function sanitize_item_id_on_save( string $value, int $id, array $field ) : string {
 	return sanitize_title( $value );
 }


### PR DESCRIPTION
Fixes #14 

Add option for offsetting the list element anchor in order to tacke the [fixed header issue](https://www.caktusgroup.com/blog/2017/10/23/css-tip-fixed-headers-and-section-anchors/) by isolating the anchor element. Offset can be added by changing top style to the anchor element, i.e:
```css
.hogan-module-expandable_list .hogan-expandable-list-item > .anchor {
  top: -4.5em;
}
```
