### PR TITLE
Change how height is used with the list item container

### DIFF
--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -12,7 +12,7 @@
 		// Toggle item panel active state.
 		var panel = this.nextElementSibling;
 		panel.setAttribute( 'aria-expanded', this.classList.contains( 'active' ).toString() );
-		panel.style.maxHeight = this.classList.contains( 'active' ) ? panel.scrollHeight + 'px' : '0';
+		panel.style.maxHeight = this.classList.contains( 'active' ) ? 'initial' : '0';
 	};
 
 	var itemLinks = document.querySelectorAll( '.hogan-expandable-list-item > a' );


### PR DESCRIPTION
This removes the calculation trying to work with `scrollHeight`, which can be unreliable at times, with the `initial` value.

This will reet the height to the browsers calculated size based on complete content, and if content needs ot shift due to lazy laoding or similar, it will re-size accordingly.